### PR TITLE
Put a color legend on the main page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -13,10 +13,10 @@
         <p><u>Statistics</u></p>
         <ul>
             <li>Packages to rebuild (based on Python 3.12): <b>{{ number_pkgs_to_rebuild }}</b> (100%)</li>
-            <li>Packages built successfully with Python 3.13: <b>{{ number_pkgs_success }}</b> ({{ "{:.2f}%".format(number_pkgs_success*100/number_pkgs_to_rebuild) }})</li>
-            <li>Packages built successfully with Python 3.13 (last build failed though): <b>{{ number_pkgs_flaky }}</b> ({{ "{:.2f}%".format(number_pkgs_flaky*100/number_pkgs_to_rebuild) }})</li>
-            <li>Packages that failed to build with Python 3.13: <b>{{ number_pkgs_failed }}</b> ({{ "{:.2f}%".format(number_pkgs_failed*100/number_pkgs_to_rebuild) }})</li>
-            <li>Packages not yet attempted to build (blocked on missing dependencies): <b>{{ number_pkgs_waiting }}</b> ({{ "{:.2f}%".format(number_pkgs_waiting*100/number_pkgs_to_rebuild) }})</li>
+            <li>🟢 Packages built successfully with Python 3.13: <b>{{ number_pkgs_success }}</b> ({{ "{:.2f}%".format(number_pkgs_success*100/number_pkgs_to_rebuild) }})</li>
+            <li>🟠 Packages built successfully with Python 3.13 (last build failed though): <b>{{ number_pkgs_flaky }}</b> ({{ "{:.2f}%".format(number_pkgs_flaky*100/number_pkgs_to_rebuild) }})</li>
+            <li>🔴 Packages that failed to build with Python 3.13: <b>{{ number_pkgs_failed }}</b> ({{ "{:.2f}%".format(number_pkgs_failed*100/number_pkgs_to_rebuild) }})</li>
+            <li>⚪ Packages not yet attempted to build (blocked on missing dependencies): <b>{{ number_pkgs_waiting }}</b> ({{ "{:.2f}%".format(number_pkgs_waiting*100/number_pkgs_to_rebuild) }})</li>
         </ul>
 
         <h2>Status breakdown</h2>


### PR DESCRIPTION
When I saw “Packages that fail to build (🔴 + 🟠)” I followed the “Take me home” link, and it wasn't clear where to go to see an explanation of the colours.