### PR TITLE
Use grey text readable in light and dark modes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -63,6 +63,9 @@
         border-color: #333;
       }
     }
+    .text-default {
+      color: #777;
+    }
   </style>
   {% block head %}{% endblock %}
   <title>{% block title %}{% endblock %}</title>

--- a/templates/wheels.html
+++ b/templates/wheels.html
@@ -52,7 +52,7 @@
       {%- set do_support_percent = (do_support / results|length * 100)|round(1) -%}
       {%- set no_support_percent = (no_support / results|length * 100)|round(1) -%}
       <li>{{ do_support }} <span class="text-success">green</span> packages ({{ do_support_percent }}%) publish Python {{ major }} compatible wheels;</li>
-      <li>{{ no_support }} <span class="text-muted">white</span> packages ({{ no_support_percent }}%) don't publish Python {{ major }} compatible wheels.</li>
+      <li>{{ no_support }} <span class="text-default">white</span> packages ({{ no_support_percent }}%) don't publish Python {{ major }} compatible wheels.</li>
     </ol>
     <h2>Package 'x' is white. What can I do?</h2>
       <p>There can be many reasons a package is not explicitly supporting Python {{ major }}:</p>


### PR DESCRIPTION
It's hard to read the word "white" for the second bullet:

![image](https://github.com/user-attachments/assets/d1cdab72-f687-4c62-a21f-09a3d842bc85)

`text-muted` is different in Bootstrap 5 compared with Bootstrap 3 used by pythonwheels, so set it to a grey colour that works better for both light and dark.

This is the colour I used at https://hugovk.github.io/free-threaded-wheels/

I've not actually tested this -- how can I run it locally? But it should look like:

![image](https://github.com/user-attachments/assets/dbb84286-dccd-471d-8fd1-805474586889)
![image](https://github.com/user-attachments/assets/b2e2e0e0-e588-4f93-a4ec-b1a751955eff)

