### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -35,4 +35,4 @@ curl https://src.fedoraproject.org/extras/pagure_owner_alias.json -o data/pagure
 python3 scripts/bugzillas.py
 
 # download the most downloaded packages from PyPI
-wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json -O data/top-pypi-packages.json
+wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json -O data/top-pypi-packages.json


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.