### PR TITLE
encode packages name for koji url

### DIFF
--- a/templates/failures_py315.html
+++ b/templates/failures_py315.html
@@ -28,7 +28,7 @@
                 <td>{{ package_name }}</td>
                 <td>{{ detail["state"] }}</td>
                 <td>
-                    <a href="https://koji.fedoraproject.org/koji/search?terms={{ package_name }}&type=package&match=exact">
+                    <a href="https://koji.fedoraproject.org/koji/search?terms={{ urllib.parse.quote(package_name) }}&type=package&match=exact">
                         Koji - {{ package_name }}
                     </a>
                 </td>


### PR DESCRIPTION
Right now the bout++ link goes to https://koji.fedoraproject.org/koji/search?terms=bout++&type=package&match=exact - so koji looks for `bout` rather then `bout++`.